### PR TITLE
no-jira: improvement to the verify-capi-manifests scripts

### DIFF
--- a/docs/dev/dependencies.md
+++ b/docs/dev/dependencies.md
@@ -71,7 +71,16 @@ go mod tidy && go mod vendor
 
 When bumping version of the CAPI provider, some infrastructure CRDs might be updated and we need to ensure the installer is aware of that as it keeps a copy of the CRD in directory `data/data/cluster-api/`.
 
-First, clone the upstream CAPI provider project.
+An easy way to update the infrastructure manifests is to run `./hack/verify-capi-manifests.sh [provider-dir]`:
+
+```bash
+# Update infrastructure manifests for all providers
+./hack/verify-capi-manifests.sh
+# Or update infrastructure manifest for a specific provider (e.g. aws)
+./hack/verify-capi-manifests.sh cluster-api/providers/aws
+```
+
+Another way is to manually do it yourself. First, clone the upstream CAPI provider project.
 
 ```bash
 # We need to have a copy of the CAPI provider project if not yet

--- a/hack/verify-capi-manifests.sh
+++ b/hack/verify-capi-manifests.sh
@@ -2,6 +2,75 @@
 
 MANIFESTS_DIR="/go/src/github.com/openshift/installer/data/data/cluster-api"
 
+# Generate provider manifest from released assets
+generate_capi_manifest_from_released_assets() {
+	echo "Generating ${provider} manifest from released assets"
+	provider="$1"
+	repo_origin="$2"
+	version="$3"
+
+	# Not a version, but a revision
+	if [[ ! "$version" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$  ]]; then
+		return 1
+	fi
+
+	# Core CAPI generates cluster-api-components.yaml
+	# while provider generates infrastructure-components.yaml
+	case "${provider}" in
+	cluster-api)
+		asset_name="cluster-api-components.yaml"
+		saved_asset_name="${MANIFESTS_DIR}/core-components.yaml"
+		;;
+	*)
+		asset_name="infrastructure-components.yaml"
+		saved_asset_name="${MANIFESTS_DIR}/${provider}-infrastructure-components.yaml"
+		;;
+	esac
+
+	if ! curl -fSsL -o "${saved_asset_name}" "$repo_origin/releases/download/${version}/${asset_name}"; then
+		echo "Failed generating ${provider} manifest from released assets. Falling back to generate from specified revision"
+		return 1
+	fi
+}
+
+# Generate provider manifest from specified revision
+generate_capi_manifest_from_revision() {
+	echo "Generating ${provider} manifest from specified revision"
+	provider="$1"
+	repo_origin="$2"
+	revision="$3"
+
+	clone_path="$(mktemp -d)"
+	git clone "${repo_origin}" "${clone_path}"
+	pushd "${clone_path}"
+	git fetch "${repo_origin}" "${revision}"
+	git checkout "${revision}"
+
+	# Provider-specific generate command
+	case "${provider}" in
+	vsphere)
+		make release-manifests-all
+		;;
+	*)
+		make release-manifests
+		;;
+	esac
+
+	# Core CAPI generates cluster-api-components.yaml
+	# while provider generates infrastructure-components.yaml
+	# except azureaso that needs combining 2 manifests.
+	case "${provider}" in
+	cluster-api)
+		cp out/cluster-api-components.yaml "${MANIFESTS_DIR}/core-components.yaml"
+		;;
+	*)
+		cp out/infrastructure-components.yaml "${MANIFESTS_DIR}/${provider}-infrastructure-components.yaml"
+		;;
+	esac
+	popd
+	rm -rf "${clone_path}"
+}
+
 generate_capi_manifest() {
 	provider="$(basename "$1")"
 
@@ -17,59 +86,40 @@ generate_capi_manifest() {
 	repo_origin="$(jq '.Origin.URL' "${info_path}" | sed 's|"||g')"
 	revision="$(jq '.Origin.Hash' "${info_path}" | sed 's|"||g')"
 
-	if [ "${provider}" = "azureaso" ]; then
-		# Just copy the CRD from upstream
-		curl -fSsL "https://github.com/Azure/azure-service-operator/releases/download/${version}/azureserviceoperator_${version}.yaml" -o "${MANIFESTS_DIR}/${provider}-infrastructure-components.yaml"
-		echo "---" >>"${MANIFESTS_DIR}/${provider}-infrastructure-components.yaml"
-		curl -fSsL "https://github.com/Azure/azure-service-operator/releases/download/${version}/azureserviceoperator_customresourcedefinitions_${version}.yaml" >>"${MANIFESTS_DIR}/${provider}-infrastructure-components.yaml"
-	else
-		# Generate provider manifest from specified revision
-		clone_path="$(mktemp -d)"
-		git clone "${repo_origin}" "${clone_path}"
-		pushd "${clone_path}"
-		git fetch "${repo_origin}" "${revision}"
-		git checkout "${revision}"
-		case "${provider}" in
+	case "${provider}" in
 		azurestack)
 		    # skip this for now--until unforked
 			;;
-		vsphere)
-			make release-manifests-all
+		azureaso)
+			# Just copy the CRD from upstream release assets
+			curl -fSsL "https://github.com/Azure/azure-service-operator/releases/download/${version}/azureserviceoperator_${version}.yaml" -o "${MANIFESTS_DIR}/${provider}-infrastructure-components.yaml"
+			echo "---" >>"${MANIFESTS_DIR}/${provider}-infrastructure-components.yaml"
+			curl -fSsL "https://github.com/Azure/azure-service-operator/releases/download/${version}/azureserviceoperator_customresourcedefinitions_${version}.yaml" >>"${MANIFESTS_DIR}/${provider}-infrastructure-components.yaml"
 			;;
 		*)
-			make release-manifests
+			# Attempt to find the infrastructure manifest in the released assets
+			# If none is found, generate the infrastucture manifests from the pinned revision
+			generate_capi_manifest_from_released_assets "$provider" "$repo_origin" "$version" || \
+			generate_capi_manifest_from_revision "$provider" "$repo_origin" "$revision"
 			;;
-		esac
-
-		case "${provider}" in
-		cluster-api)
-			cp out/cluster-api-components.yaml "${MANIFESTS_DIR}/core-components.yaml"
-			;;
-		*)
-			cp out/infrastructure-components.yaml "${MANIFESTS_DIR}/${provider}-infrastructure-components.yaml"
-			;;
-		esac
-		popd
-		rm -rf "${clone_path}"
-	fi
+	esac
 }
 
 if [ "$IS_CONTAINER" != "" ]; then
 	set -eux
 
 	# Install `jq` if not present
-	if ! command -v jq; then
+	if ! command -v jq >/dev/null 2>&1; then
 		curl -L https://github.com/jqlang/jq/releases/download/jq-1.7.1/jq-linux-amd64 -o /usr/bin/jq
 		chmod u+x /usr/bin/jq
 	fi
 
-
 	# Install `controller-gen` & `kustomize`, which are needed by nutanix, if not present
-	if ! command -v controller-gen; then
+	if ! command -v controller-gen >/dev/null 2>&1; then
 		go install sigs.k8s.io/controller-tools/cmd/controller-gen
 	fi
 
-	if ! command -v kustomize; then
+	if ! command -v kustomize >/dev/null 2>&1; then
 		go install sigs.k8s.io/kustomize/kustomize/v5@latest
 	fi
 


### PR DESCRIPTION
This improvement includes trying out the released assets first if any. In case that fails (i.e. not a version, or non-existing asset URL), fall back to generate from pinned revision.

Some ideas for your considerations :smiley:
